### PR TITLE
Readme update - spelling and grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,5 +316,5 @@ You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the #License for the specific language governing permissions and
+See the License for the specific language governing permissions and
 limitations under the License.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ https://ghost.org/
 ## Docker Compose
 
 ```bash
-$ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-ghost/master/docker-compose.yml > docker-compose.yml
-$ docker-compose up -d
+curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-ghost/master/docker-compose.yml > docker-compose.yml
+docker-compose up -d
 ```
 
 ## Kubernetes
@@ -24,7 +24,7 @@ $ docker-compose up -d
 Get the raw URL pointing to the `kubernetes.yml` manifest and use `kubectl` to create the resources on your Kubernetes cluster like so:
 
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/bitnami/bitnami-docker-ghost/master/kubernetes.yml
+kubectl create -f https://raw.githubusercontent.com/bitnami/bitnami-docker-ghost/master/kubernetes.yml
 ```
 
 # Why use Bitnami Images?
@@ -80,32 +80,32 @@ If you want to run the application manually instead of using docker-compose, the
 1. Create a new network for the application and the database:
 
   ```bash
-  $ docker network create ghost-tier
+  docker network create ghost-tier
   ```
 
 2. Start a MariaDB database in the network generated:
 
    ```bash
-   $ docker run -d --name mariadb --net=ghost-tier \
+   docker run -d --name mariadb --net=ghost-tier \
       -e ALLOW_EMPTY_PASSWORD=yes \
       bitnami/mariadb
    ```
 
-   *Note:* You need to give the container a name in order to Ghost to resolve the host
+   *Note:* You need to give the container a name in order for Ghost to resolve the host
 
 3. Run the Ghost container:
 
   ```bash
-  $ docker run -d -p 80:2368 --name ghost --net=ghost-tier bitnami/ghost
+  docker run -d -p 80:2368 --name ghost --net=ghost-tier bitnami/ghost
   ```
 
 Then you can access your application at http://your-ip/
 
-> **Note!** If you want to access your application from a public IP or hostname you need to properly configured Ghost . You can handle it adjusting the configuration of the instance by setting the environment variable `GHOST_HOST` to your public IP or hostname.
+> **Note!** If you want to access your application from a public IP or hostname you need to properly configure your Ghost instance. You can handle it by adjusting the configuration of the environment variable `GHOST_HOST` to your public IP or hostname.
 
 ## Persisting your application
 
-If you remove the container all your data and configurations will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
+If you remove the container, all of your data and configuration will be lost. The next time you run the image, the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
 For persistence you should mount a volume at the `/bitnami` path. Additionally you should mount a volume for [persistence of the MariaDB data](https://github.com/bitnami/bitnami-docker-mariadb#persisting-your-database).
 
@@ -144,24 +144,24 @@ In this case you need to specify the directories to mount on the run command. Th
 1. Create a network (if it does not exist):
 
   ```bash
-  $ docker network create ghost-tier
+  docker network create ghost-tier
   ```
 
 2. Create a MariaDB container with host volume:
 
   ```bash
-  $ docker run -d --name mariadb --net ghost-tier \
+  docker run -d --name mariadb --net ghost-tier \
     -e ALLOW_EMPTY_PASSWORD=yes \
     --volume /path/to/mariadb-persistence:/bitnami \
     bitnami/mariadb:latest
   ```
 
-  *Note:* You need to give the container a name in order to Ghost to resolve the host
+  *Note:* You need to give the container a name in order for Ghost to resolve to your hostname.
 
 3. Create the Ghost container with host volumes:
 
   ```bash
-  $ docker run -d --name ghost -p 80:2368 --net ghost-tier \
+  docker run -d --name ghost -p 80:2368 --net ghost-tier \
     --volume /path/to/ghost-persistence:/bitnami \
     bitnami/ghost:latest
   ```
@@ -173,18 +173,18 @@ Bitnami provides up-to-date versions of MariaDB and Ghost, including security pa
 1. Get the updated images:
 
   ```bash
-  $ docker pull bitnami/ghost:latest
+  docker pull bitnami/ghost:latest
   ```
 
 2. Stop your container
 
- * For docker-compose: `$ docker-compose stop ghost`
- * For manual execution: `$ docker stop ghost`
+ * For docker-compose: `docker-compose stop ghost`
+ * For manual execution: `docker stop ghost`
 
 3. Take a snapshot of the application state
 
 ```bash
-$ rsync -a /path/to/ghost-persistence /path/to/ghost-persistence.bkp.$(date +%Y%m%d-%H.%M.%S)
+rsync -a /path/to/ghost-persistence /path/to/ghost-persistence.bkp.$(date +%Y%m%d-%H.%M.%S)
 ```
 
 Additionally, [snapshot the MariaDB data](https://github.com/bitnami/bitnami-docker-mariadb#step-2-stop-and-backup-the-currently-running-container)
@@ -193,12 +193,12 @@ You can use these snapshots to restore the application state should the upgrade 
 
 4. Remove the currently running container
 
- * For docker-compose: `$ docker-compose rm ghost`
- * For manual execution: `$ docker rm ghost`
+ * For docker-compose: `docker-compose rm ghost`
+ * For manual execution: `docker rm ghost`
 
 5. Run the new image
 
- * For docker-compose: `$ docker-compose start ghost`
+ * For docker-compose: `docker-compose start ghost`
  * For manual execution ([mount](#mount-persistent-folders-manually) the directories if needed): `docker run --name ghost bitnami/ghost:latest`
 
 # Configuration
@@ -221,7 +221,7 @@ ghost:
  * For manual execution add a `-e` option with each variable and value:
 
 ```bash
- $ docker run -d -p 80:2368 --name ghost --network=ghost-tier \
+ docker run -d -p 80:2368 --name ghost --network=ghost-tier \
     -e GHOST_PASSWORD=my_password \
     -v /your/local/path/bitnami/ghost:/bitnami \
     bitnami/ghost
@@ -248,7 +248,7 @@ To configure Ghost to send email using SMTP you can set the following environmen
  - `SMTP_PASSWORD`: SMTP account password.
  - `SMTP_SERVICE`: SMTP service to use.
 
-This would be an example of SMTP configuration using a GMail account:
+This would be an example of SMTP configuration using a Gmail account:
 
  * docker-compose:
 
@@ -267,7 +267,7 @@ This would be an example of SMTP configuration using a GMail account:
  * For manual execution:
 
 ```bash
- $ docker run -d -p 80:2368 --name ghost --network=ghost-tier \
+ docker run -d -p 80:2368 --name ghost --network=ghost-tier \
     -e SMTP_HOST=smtp.gmail.com \
     -e SMTP_SERVICE=GMail \
     -e SMTP_USER=your_email@gmail.com \
@@ -280,7 +280,7 @@ This would be an example of SMTP configuration using a GMail account:
 
 ## 0.11.10-r2
 
-- The ghost container has been migrated to a non-root container approach. Previously the container run as `root` user and the ghost daemon was started as `ghost` user. From now own, both the container and the ghost daemon run as user `1001`.
+- The ghost container has been migrated to a non-root container approach. Previously the container run as `root` user and the ghost daemon was started as `ghost` user. From now on, both the container and the ghost daemon run as user `1001`.
   As a consequence, the configuration files are writable by the user running the ghost process.
 
 # Contributing
@@ -289,26 +289,26 @@ We'd love for you to contribute to this container. You can request new features 
 
 # Issues
 
-If you encountered a problem running this container, you can file an [issue](https://github.com/bitnami/bitnami-docker-ghost/issues). For us to provide better support, be sure to include the following information in your issue:
+If you encountered a problem running this container, you can file an [issue](https://github.com/bitnami/bitnami-docker-ghost/issues). For us to provide better support. Be sure to include the following information in your issue:
 
 - Host OS and version
-- Docker version (`docker version`)
+- Docker version `docker version`
 - Output of `docker info`
-- Version of this container (`echo $BITNAMI_IMAGE_VERSION` inside the container)
-- The command you used to run the container, and any relevant output you saw (masking any sensitive information)
+- Version of this container `echo $BITNAMI_IMAGE_VERSION` (inside the container)
+- The command you used to run the container and any relevant output. Don't forget to mask any sensitive information.
 
 # Community
 
-Most real time communication happens in the `#containers` channel at [bitnami-oss.slack.com](http://bitnami-oss.slack.com); you can sign up at [slack.oss.bitnami.com](http://slack.oss.bitnami.com).
+Most real time communication happens in the `#containers` channel at [bitnami-oss.slack.com](http://bitnami-oss.slack.com). You can sign up at [slack.oss.bitnami.com](http://slack.oss.bitnami.com).
 
 Discussions are archived at [bitnami-oss.slackarchive.io](https://bitnami-oss.slackarchive.io).
 
-# License
+# [License](#LICENSE)
 
 Copyright 2016-2017 Bitnami
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
@@ -316,5 +316,5 @@ You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
+See the #License for the specific language governing permissions and
 limitations under the License.


### PR DESCRIPTION
Description of the change
Made some modifications to the README. I corrected some spelling and grammar and made it easier to copy the commands inside backticks.

Benefits
They are minor, but make your README appear more professional.

Possible drawbacks
None. I merged the latest changes to master.